### PR TITLE
Fix deprecation + remove tests not required anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 group :runtime do
   gem "myrrha", "~> 3.0"
   gem "domain", "~> 1.0"
-  gem "path", "~> 1.3"
+  gem "path", "~> 2.0"
   gem "sexpr", "~> 0.6.0"
 end
 

--- a/alf-core.noespec
+++ b/alf-core.noespec
@@ -18,7 +18,7 @@ variables:
   upper:
     Core
   version:
-    0.17.0
+    0.17.2
   summary: |-
     Relational Algebra at your fingertips
   description: |-

--- a/lib/alf/core/version.rb
+++ b/lib/alf/core/version.rb
@@ -4,7 +4,7 @@ module Alf
 
       MAJOR = 0
       MINOR = 17
-      TINY  = 1
+      TINY  = 2
 
       def self.to_s
         [ MAJOR, MINOR, TINY ].join('.')

--- a/spec/integration/test_alf.rb
+++ b/spec/integration/test_alf.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 describe Alf::Core do
-  
+
   it "has a version number" do
-    Alf::Core.const_defined?(:VERSION).should be_true
+    Alf::Core.const_defined?(:VERSION).should be_truthy
   end
-  
+
 end

--- a/spec/shared/a_scope.rb
+++ b/spec/shared/a_scope.rb
@@ -1,21 +1,21 @@
 shared_examples_for "A scope" do
 
   it 'responds to its own methods' do
-    subject.respond_to?(:respond_to?).should be_true
-    subject.respond_to?(:evaluate).should be_true
-    subject.respond_to?(:__eval_binding).should be_true
+    subject.respond_to?(:respond_to?).should be_truthy
+    subject.respond_to?(:evaluate).should be_truthy
+    subject.respond_to?(:__eval_binding).should be_truthy
   end
 
   it 'responds to needed kernel methods' do
-    subject.respond_to?(:lambda).should be_true
+    subject.respond_to?(:lambda).should be_truthy
   end
 
   it "responds to BasicObject's API" do
-    subject.respond_to?(:instance_eval).should be_true
+    subject.respond_to?(:instance_eval).should be_truthy
   end
-  
+
   it 'does not respond to anything' do
-    subject.respond_to?(:anything_else).should be_false
+    subject.respond_to?(:anything_else).should be_falsey
   end
 
 end

--- a/spec/shared/a_valid_type_implementation.rb
+++ b/spec/shared/a_valid_type_implementation.rb
@@ -3,7 +3,7 @@ shared_examples_for "A valid type implementation" do
   it 'should have exemplars available' do
     type.exemplars.should_not be_empty
     type.exemplars.each do |value|
-      (type === value).should be_true
+      (type === value).should be_truthy
     end
   end
 

--- a/spec/shared/an_operator_class.rb
+++ b/spec/shared/an_operator_class.rb
@@ -40,10 +40,10 @@ shared_examples_for "An operator class" do
 
   it "should implement unary? and binary? consistently" do
     op = operator_class
-    (op.nullary? || op.unary? || op.binary?).should be_true
-    (op.nullary? && op.unary?).should be_false
-    (op.nullary? && op.binary?).should be_false
-    (op.unary? && op.binary?).should be_false
+    (op.nullary? || op.unary? || op.binary?).should be_truthy
+    (op.nullary? && op.unary?).should be_falsey
+    (op.nullary? && op.binary?).should be_falsey
+    (op.unary? && op.binary?).should be_falsey
   end
 
 end

--- a/spec/unit/alf-adapter-fs/folder/test_adapter_class.rb
+++ b/spec/unit/alf-adapter-fs/folder/test_adapter_class.rb
@@ -14,7 +14,7 @@ module Alf
       describe "recognizes?" do
 
         it 'is not be too permissive' do
-          Folder.recognizes?("not/an/existing/one").should be_false
+          Folder.recognizes?("not/an/existing/one").should be_falsey
         end
       end
 

--- a/spec/unit/alf-adapter/connection/test_lock.rb
+++ b/spec/unit/alf-adapter/connection/test_lock.rb
@@ -8,7 +8,7 @@ module Alf
 
       it 'yields the block' do
         subject
-        @seen.should be_true
+        @seen.should be_truthy
       end
 
     end

--- a/spec/unit/alf-adapter/shared_examples/an_adapter_class.rb
+++ b/spec/unit/alf-adapter/shared_examples/an_adapter_class.rb
@@ -4,7 +4,7 @@ shared_examples_for "an adapter class" do
 
     it 'returns true on recognized connection specifications' do
       recognized_conn_specs.each do |c|
-        adapter_class.recognizes?(c).should be_true
+        adapter_class.recognizes?(c).should be_truthy
       end
     end
   end

--- a/spec/unit/alf-adapter/shared_examples/an_adapter_with_readable_cogs.rb
+++ b/spec/unit/alf-adapter/shared_examples/an_adapter_with_readable_cogs.rb
@@ -14,7 +14,7 @@ shared_examples_for "an adapter with readable cogs" do
 
     it 'respond true to known cogs' do
       readable_cogs.each do |cog_name|
-        connection.knows?(cog_name).should be_true
+        connection.knows?(cog_name).should be_truthy
       end
     end
   end

--- a/spec/unit/alf-algebra/operator/allbut/test_key_preserving.rb
+++ b/spec/unit/alf-algebra/operator/allbut/test_key_preserving.rb
@@ -11,19 +11,19 @@ module Alf
       subject{ op.key_preserving? }
 
       context 'when conserving at least one key' do
-        let(:op){ 
+        let(:op){
           a_lispy.allbut(operand, [:name])
         }
 
-        it { should be_true }
+        it { should be_truthy }
       end
 
       context 'when projecting all keys away' do
-        let(:op){ 
+        let(:op){
           a_lispy.allbut(operand, [:id, :name])
         }
 
-        it { should be_false }
+        it { should be_falsey }
       end
 
       context 'when the operand is a restriction on the key' do
@@ -35,7 +35,7 @@ module Alf
           a_lispy.allbut(a_lispy.restrict(operand, sid: 1), [:name])
         }
 
-        it { should be_true }
+        it { should be_truthy }
       end
 
       context 'when a key is projected due to a constant restriction' do
@@ -47,7 +47,7 @@ module Alf
           a_lispy.allbut(a_lispy.restrict(operand, sid: 1), [:sid])
         }
 
-        it { should be_true }
+        it { should be_truthy }
       end
 
     end

--- a/spec/unit/alf-algebra/operator/commons/test_with_operands.rb
+++ b/spec/unit/alf-algebra/operator/commons/test_with_operands.rb
@@ -20,13 +20,13 @@ module Alf
       it "replaces the operands but keeps params unchanged" do
         subject.operands.first.should be(operand_2)
         subject.attributes.should eq(AttrList[:foo])
-        subject.allbut.should be_true
+        subject.allbut.should be_truthy
       end
 
       it "keeps the original unchanged" do
         operator.operands.first.should be(operand_1)
         subject.attributes.should eq(AttrList[:foo])
-        subject.allbut.should be_true
+        subject.allbut.should be_truthy
       end
 
       it 'does not keep computed heading from the original' do

--- a/spec/unit/alf-algebra/operator/defaults/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/defaults/test_heading.rb
@@ -10,7 +10,7 @@ module Alf
       subject{ op.heading }
 
       context '--no-strict' do
-        let(:op){ 
+        let(:op){
           a_lispy.defaults(operand, {:id => lambda{12}})
         }
         let(:expected){
@@ -18,7 +18,7 @@ module Alf
         }
 
         it {
-          pending "type inference on expressions not implemented" do
+          skip "type inference on expressions not implemented" do
             should eq(expected)
           end
         }
@@ -27,7 +27,7 @@ module Alf
       end
 
       context '--strict' do
-        let(:op){ 
+        let(:op){
           a_lispy.defaults(operand, {:id => lambda{12}}, :strict => true)
         }
         let(:expected){
@@ -35,7 +35,7 @@ module Alf
         }
 
         it {
-          pending "type inference on expressions not implemented" do
+          skip "type inference on expressions not implemented" do
             should eq(expected)
           end
         }

--- a/spec/unit/alf-algebra/operator/extend/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/extend/test_heading.rb
@@ -17,8 +17,8 @@ module Alf
           Heading[:name => String, :computed => Integer]
         }
 
-        it { 
-          pending "type inference on expressions not implemented" do
+        it {
+          skip "type inference on expressions not implemented" do
             should eq(expected)
           end
         }

--- a/spec/unit/alf-algebra/operator/intersect/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/intersect/test_heading.rb
@@ -16,7 +16,7 @@ module Alf
         let(:right){
           an_operand.with_heading(:id => Integer, :name => String)
         }
-        let(:op){ 
+        let(:op){
           a_lispy.intersect(left, right)
         }
 
@@ -25,9 +25,9 @@ module Alf
 
       context 'with some subtypes' do
         let(:right){
-          an_operand.with_heading(:id => Fixnum, :name => String)
+          an_operand.with_heading(:id => Integer, :name => String)
         }
-        let(:op){ 
+        let(:op){
           a_lispy.intersect(left, right)
         }
 

--- a/spec/unit/alf-algebra/operator/join/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/join/test_heading.rb
@@ -7,7 +7,7 @@ module Alf
         an_operand.with_heading(:id => Integer, :name => String)
       }
 
-      let(:op){ 
+      let(:op){
         a_lispy.intersect(left, right)
       }
       subject{ op.heading }
@@ -25,7 +25,7 @@ module Alf
 
       context 'when non-disjoint headings' do
         let(:right){
-          an_operand.with_heading(:id => Fixnum, :foo => String)
+          an_operand.with_heading(:id => Integer, :foo => String)
         }
         let(:expected){
           Heading[:id => Integer, :name => String, :foo => String]

--- a/spec/unit/alf-algebra/operator/join/test_keys.rb
+++ b/spec/unit/alf-algebra/operator/join/test_keys.rb
@@ -3,7 +3,7 @@ module Alf
   module Algebra
     describe Join, 'keys' do
 
-      let(:op){ 
+      let(:op){
         a_lispy.join(left, right)
       }
       subject{ op.keys }
@@ -34,7 +34,7 @@ module Alf
         }
 
         it {
-          pending "join key inference could be smarter" do
+          skip "join key inference could be smarter" do
             should eq(expected)
           end
         }

--- a/spec/unit/alf-algebra/operator/matching/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/matching/test_heading.rb
@@ -4,19 +4,19 @@ module Alf
     describe Matching, 'heading' do
 
       let(:left){
-        an_operand.with_heading(:id => Fixnum, :name => String)
+        an_operand.with_heading(:id => Integer, :name => String)
       }
       let(:right){
         an_operand.with_heading(:id => Integer, :foo => String)
       }
 
-      let(:op){ 
+      let(:op){
         a_lispy.matching(left, right)
       }
       subject{ op.heading }
 
       let(:expected){
-        Heading[:id => Fixnum, :name => String]
+        Heading[:id => Integer, :name => String]
       }
 
       it { should eq(expected) }

--- a/spec/unit/alf-algebra/operator/matching/test_keys.rb
+++ b/spec/unit/alf-algebra/operator/matching/test_keys.rb
@@ -3,14 +3,14 @@ module Alf
   module Algebra
     describe Matching, 'keys' do
 
-      let(:op){ 
+      let(:op){
         a_lispy.matching(left, right)
       }
       subject{ op.keys }
 
       context 'when matching does not occurs on a right key' do
         let(:left){
-          an_operand.with_heading(:id => Fixnum, :name => String).with_keys([ :id ])
+          an_operand.with_heading(:id => Integer, :name => String).with_keys([ :id ])
         }
         let(:right){
           an_operand.with_heading(:id => Integer, :foo => String).with_keys([ :foo ])
@@ -25,7 +25,7 @@ module Alf
 
       context 'when matching does occur on a right key' do
         let(:left){
-          an_operand.with_heading(:id => Fixnum, :name => String).with_keys([ :name ])
+          an_operand.with_heading(:id => Integer, :name => String).with_keys([ :name ])
         }
         let(:right){
           an_operand.with_heading(:id => Integer, :foo => String).with_keys([ :id ])

--- a/spec/unit/alf-algebra/operator/minus/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/minus/test_heading.rb
@@ -4,19 +4,19 @@ module Alf
     describe Minus, 'heading' do
 
       let(:left){
-        an_operand.with_heading(:id => Fixnum, :name => String)
+        an_operand.with_heading(:id => Integer, :name => String)
       }
       let(:right){
         an_operand.with_heading(:id => Integer, :name => String)
       }
 
-      let(:op){ 
+      let(:op){
         a_lispy.minus(left, right)
       }
       subject{ op.heading }
 
       let(:expected){
-        Heading[:id => Fixnum, :name => String]
+        Heading[:id => Integer, :name => String]
       }
 
       it { should eq(expected) }

--- a/spec/unit/alf-algebra/operator/minus/test_keys.rb
+++ b/spec/unit/alf-algebra/operator/minus/test_keys.rb
@@ -4,13 +4,13 @@ module Alf
     describe Minus, 'keys' do
 
       let(:left){
-        an_operand.with_heading(:id => Fixnum, :name => String).with_keys([ :id ])
+        an_operand.with_heading(:id => Integer, :name => String).with_keys([ :id ])
       }
       let(:right){
         an_operand.with_heading(:id => Integer, :name => String)
       }
 
-      let(:op){ 
+      let(:op){
         a_lispy.minus(left, right)
       }
       subject{ op.keys }

--- a/spec/unit/alf-algebra/operator/not_matching/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/not_matching/test_heading.rb
@@ -4,19 +4,19 @@ module Alf
     describe NotMatching, 'heading' do
 
       let(:left){
-        an_operand.with_heading(:id => Fixnum, :name => String)
+        an_operand.with_heading(:id => Integer, :name => String)
       }
       let(:right){
         an_operand.with_heading(:id => Integer, :foo => String)
       }
 
-      let(:op){ 
+      let(:op){
         a_lispy.not_matching(left, right)
       }
       subject{ op.heading }
 
       let(:expected){
-        Heading[:id => Fixnum, :name => String]
+        Heading[:id => Integer, :name => String]
       }
 
       it { should eq(expected) }

--- a/spec/unit/alf-algebra/operator/not_matching/test_keys.rb
+++ b/spec/unit/alf-algebra/operator/not_matching/test_keys.rb
@@ -4,13 +4,13 @@ module Alf
     describe NotMatching, 'keys' do
 
       let(:left){
-        an_operand.with_heading(:id => Fixnum, :name => String).with_keys([:id])
+        an_operand.with_heading(:id => Integer, :name => String).with_keys([:id])
       }
       let(:right){
         an_operand.with_heading(:id => Integer, :foo => String)
       }
 
-      let(:op){ 
+      let(:op){
         a_lispy.not_matching(left, right)
       }
       subject{ op.keys }

--- a/spec/unit/alf-algebra/operator/project/test_key_preserving.rb
+++ b/spec/unit/alf-algebra/operator/project/test_key_preserving.rb
@@ -11,19 +11,19 @@ module Alf
       subject{ op.key_preserving? }
 
       context 'when conserving at least one key' do
-        let(:op){ 
+        let(:op){
           a_lispy.project(operand, [:id, :status])
         }
 
-        it { should be_true }
+        it { should be_truthy }
       end
 
       context 'when projecting all keys away' do
-        let(:op){ 
+        let(:op){
           a_lispy.project(operand, [:status])
         }
 
-        it { should be_false }
+        it { should be_falsey }
       end
 
       context 'when the operand is a restriction on the key' do
@@ -38,7 +38,7 @@ module Alf
           a_lispy.project(a_lispy.restrict(operand, sid: 1), [:sid])
         }
 
-        it { should be_true }
+        it { should be_truthy }
       end
 
       context 'when a key is projected due to a constant restriction' do
@@ -50,7 +50,7 @@ module Alf
           a_lispy.project(a_lispy.restrict(operand, sid: 1), [:pid])
         }
 
-        it { should be_true }
+        it { should be_truthy }
       end
 
     end

--- a/spec/unit/alf-algebra/operator/restrict/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/restrict/test_heading.rb
@@ -4,16 +4,16 @@ module Alf
     describe Restrict, 'heading' do
 
       let(:operand){
-        an_operand.with_heading(:id => Fixnum, :name => String)
+        an_operand.with_heading(:id => Integer, :name => String)
       }
 
-      let(:op){ 
+      let(:op){
         a_lispy.restrict(operand, lambda{ true })
       }
       subject{ op.heading }
 
       let(:expected){
-        Heading[:id => Fixnum, :name => String]
+        Heading[:id => Integer, :name => String]
       }
 
       it { should eq(expected) }

--- a/spec/unit/alf-algebra/operator/restrict/test_keys.rb
+++ b/spec/unit/alf-algebra/operator/restrict/test_keys.rb
@@ -7,7 +7,7 @@ module Alf
 
       context 'when the restriction does not touches existing keys' do
         let(:operand){
-          an_operand.with_heading(id: Fixnum, name: String).with_keys([:id])
+          an_operand.with_heading(id: Integer, name: String).with_keys([:id])
         }
         let(:op){
           a_lispy.restrict(operand, lambda{ true })
@@ -21,7 +21,7 @@ module Alf
 
       context 'when the restriction touches part of a key' do
         let(:operand){
-          an_operand.with_heading(id: Fixnum, name: String).with_keys([:id, :name])
+          an_operand.with_heading(id: Integer, name: String).with_keys([:id, :name])
         }
         let(:op){
           a_lispy.restrict(operand, id: 12)
@@ -35,7 +35,7 @@ module Alf
 
       context 'when the restriction touches a full key' do
         let(:operand){
-          an_operand.with_heading(id: Fixnum, name: String).with_keys([:id, :name])
+          an_operand.with_heading(id: Integer, name: String).with_keys([:id, :name])
         }
         let(:op){
           a_lispy.restrict(operand, id: 12, name: "Smith")

--- a/spec/unit/alf-algebra/operator/test_clip.rb
+++ b/spec/unit/alf-algebra/operator/test_clip.rb
@@ -13,7 +13,7 @@ module Alf
         it { should be_a(Clip) }
 
         it 'is !allbut by default' do
-          subject.allbut.should be_false
+          subject.allbut.should be_falsey
         end
       end # --no-allbut
 
@@ -23,7 +23,7 @@ module Alf
         it { should be_a(Clip) }
 
         it 'is allbut' do
-          subject.allbut.should be_true
+          subject.allbut.should be_truthy
         end
       end # --allbut
 

--- a/spec/unit/alf-algebra/operator/test_defaults.rb
+++ b/spec/unit/alf-algebra/operator/test_defaults.rb
@@ -13,7 +13,7 @@ module Alf
         it{ should be_a(Defaults) }
 
         it 'is !strict by default' do
-          subject.strict.should be_false
+          subject.strict.should be_falsey
         end
       end # --no-strict
 
@@ -23,7 +23,7 @@ module Alf
         it{ should be_a(Defaults) }
 
         it 'is strict' do
-          subject.strict.should be_true
+          subject.strict.should be_truthy
         end
       end # --strict
 

--- a/spec/unit/alf-algebra/operator/test_group.rb
+++ b/spec/unit/alf-algebra/operator/test_group.rb
@@ -13,7 +13,7 @@ module Alf
         it { should be_a(Group) }
 
         it 'is !allbut by default' do
-          subject.allbut.should be_false
+          subject.allbut.should be_falsey
         end
       end # --no-allbut
 
@@ -22,7 +22,7 @@ module Alf
         it { should be_a(Group) }
 
         it 'is allbut' do
-          subject.allbut.should be_true
+          subject.allbut.should be_truthy
         end
       end # --allbut
 

--- a/spec/unit/alf-algebra/operator/test_project.rb
+++ b/spec/unit/alf-algebra/operator/test_project.rb
@@ -13,7 +13,7 @@ module Alf
         it { should be_a(Project) }
 
         it 'is !allbut by default' do
-          subject.allbut.should be_false
+          subject.allbut.should be_falsey
         end
       end # --no-allbut
 
@@ -23,7 +23,7 @@ module Alf
         it { should be_a(Project) }
 
         it 'is allbut' do
-          subject.allbut.should be_true
+          subject.allbut.should be_truthy
         end
       end # --allbut
 

--- a/spec/unit/alf-algebra/operator/test_summarize.rb
+++ b/spec/unit/alf-algebra/operator/test_summarize.rb
@@ -17,7 +17,7 @@ module Alf
         it { should be_a(Summarize) }
 
         it 'is !allbut by default' do
-          subject.allbut.should be_false
+          subject.allbut.should be_falsey
         end
       end # --no-allbut
 
@@ -27,7 +27,7 @@ module Alf
         it { should be_a(Summarize) }
 
         it 'is allbut' do
-          subject.allbut.should be_true
+          subject.allbut.should be_truthy
         end
       end # --allbut
 

--- a/spec/unit/alf-algebra/operator/test_wrap.rb
+++ b/spec/unit/alf-algebra/operator/test_wrap.rb
@@ -14,7 +14,7 @@ module Alf
         it { should be_a(Wrap) }
 
         it 'should not be allbut' do
-          subject.allbut.should be_false
+          subject.allbut.should be_falsey
         end
       end
 
@@ -24,7 +24,7 @@ module Alf
         it { should be_a(Wrap) }
 
         it 'should be allbut' do
-          subject.allbut.should be_true
+          subject.allbut.should be_truthy
         end
       end
     end

--- a/spec/unit/alf-algebra/operator/union/test_heading.rb
+++ b/spec/unit/alf-algebra/operator/union/test_heading.rb
@@ -25,7 +25,7 @@ module Alf
 
       context 'with some subtypes' do
         let(:right){
-          an_operand.with_heading(:id => Fixnum, :name => String)
+          an_operand.with_heading(:id => Integer, :name => String)
         }
 
         it { should eq(expected) }

--- a/spec/unit/alf-algebra/support/signature/test_install.rb
+++ b/spec/unit/alf-algebra/support/signature/test_install.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 module Alf
   module Algebra
     describe Signature, '.install' do
-      
+
       let(:clazz){ Class.new(Object) }
       subject{ signature.install }
-      
+
       describe "on an empty signature" do
         let(:signature){ Signature.new(clazz) }
         it{ should eq({}) }
@@ -13,15 +13,15 @@ module Alf
           lambda{ subject }.should_not raise_error
         }
       end
-      
+
       describe "on a non empty signature" do
 
-        let(:signature){ 
+        let(:signature){
           Signature.new(clazz) do |s|
             s.argument :attrname, AttrName
             s.argument :ordering, Ordering
             s.option   :allbut,   Boolean, true
-          end 
+          end
         }
 
         it{ should eq(:allbut => true) }
@@ -33,24 +33,24 @@ module Alf
           inst.send(:"attrname=", :hello)
           inst.attrname.should eq(:hello)
         end
-   
+
         it "should have options installed as attr accessors" do
           subject
           inst = clazz.new
           inst.should respond_to(:allbut)
           inst.send(:"allbut=", true)
-          inst.allbut.should be_true
+          inst.allbut.should be_truthy
         end
 
         it "should apply auto-coercion" do
           subject
           inst = clazz.new
           inst.send(:"allbut=", "true")
-          inst.allbut.should be_true
+          inst.allbut.should be_truthy
         end
 
       end
-      
+
     end
   end
 end

--- a/spec/unit/alf-algebra/support/signature/test_option_parser.rb
+++ b/spec/unit/alf-algebra/support/signature/test_option_parser.rb
@@ -15,11 +15,11 @@ module Alf
       subject{ signature.option_parser(receiver) }
 
       specify "expected" do
-        opt = OptionParser.new 
+        opt = OptionParser.new
         opt.on("--allbut"){ receiver.send(:allbut=,true) }
         opt.on("--name=NAME"){|val| receiver.send(:name=,val) }
         opt.parse!(["--allbut","--name=world"])
-        receiver.allbut.should be_true
+        receiver.allbut.should be_truthy
         receiver.name.should eq(:world)
       end
 
@@ -27,7 +27,7 @@ module Alf
 
       it "should install option values correctly" do
         subject.parse!(["--allbut","--name=world"])
-        receiver.allbut.should be_true
+        receiver.allbut.should be_truthy
         receiver.name.should eq(:world)
       end
 

--- a/spec/unit/alf-algebra/support/with_ordering/test_total_ordering.rb
+++ b/spec/unit/alf-algebra/support/with_ordering/test_total_ordering.rb
@@ -16,7 +16,7 @@ module Alf
 
       context 'when the initial ordering covers a key' do
         let(:operand){
-          an_operand.with_heading(id: Fixnum, name: String).with_keys([:id])
+          an_operand.with_heading(id: Integer, name: String).with_keys([:id])
         }
         let(:ordering){
           Ordering.new([[:id, :desc]])
@@ -30,7 +30,7 @@ module Alf
 
       context 'when the initial ordering does not cover a key' do
         let(:operand){
-          an_operand.with_heading(id: Fixnum, name: String).with_keys([:id, :name])
+          an_operand.with_heading(id: Integer, name: String).with_keys([:id, :name])
         }
         let(:ordering){
           Ordering.new([[:name, :desc]])
@@ -44,7 +44,7 @@ module Alf
 
       context 'when no key' do
         let(:operand){
-          an_operand.with_heading(id: Fixnum, name: String)
+          an_operand.with_heading(id: Integer, name: String)
         }
         let(:ordering){
           Ordering.new([[:name, :desc]])

--- a/spec/unit/alf-compiler/default/test_allbut.rb
+++ b/spec/unit/alf-compiler/default/test_allbut.rb
@@ -18,7 +18,7 @@ module Alf
         it 'has a Clip sub-cog' do
           subject.operand.should be_a(Engine::Clip)
           subject.operand.attributes.should eq(AttrList[:a])
-          subject.operand.allbut.should be_true
+          subject.operand.allbut.should be_truthy
         end
 
         it 'has the corect sub-sub cog' do
@@ -52,7 +52,7 @@ module Alf
         it 'has a Clip cog' do
           subject.should be_a(Engine::Clip)
           subject.attributes.should eq(AttrList[:a])
-          subject.allbut.should be_true
+          subject.allbut.should be_truthy
         end
 
         it 'has the correct sub cog' do

--- a/spec/unit/alf-compiler/default/test_group.rb
+++ b/spec/unit/alf-compiler/default/test_group.rb
@@ -26,7 +26,7 @@ module Alf
       end
 
       it 'has the correct allbut' do
-        subject.allbut.should be_true
+        subject.allbut.should be_truthy
       end
 
       it 'has the correct sub-cog' do

--- a/spec/unit/alf-compiler/default/test_hierarchize.rb
+++ b/spec/unit/alf-compiler/default/test_hierarchize.rb
@@ -8,7 +8,7 @@ module Alf
       }
 
       let(:operand){
-        an_operand.with_heading(id: Fixnum, parent: Integer).with_keys([:id])
+        an_operand.with_heading(id: Integer, parent: Integer).with_keys([:id])
       }
 
       let(:expr){

--- a/spec/unit/alf-compiler/default/test_matching.rb
+++ b/spec/unit/alf-compiler/default/test_matching.rb
@@ -30,7 +30,7 @@ module Alf
       end
 
       it 'has the correct predicate' do
-        subject.predicate.should be_true
+        subject.predicate.should be_truthy
       end
 
     end

--- a/spec/unit/alf-compiler/default/test_minus.rb
+++ b/spec/unit/alf-compiler/default/test_minus.rb
@@ -30,7 +30,7 @@ module Alf
       end
 
       it 'has the correct predicate' do
-        subject.predicate.should be_false
+        subject.predicate.should be_falsey
       end
 
     end

--- a/spec/unit/alf-compiler/default/test_not_matching.rb
+++ b/spec/unit/alf-compiler/default/test_not_matching.rb
@@ -30,7 +30,7 @@ module Alf
       end
 
       it 'has the correct predicate' do
-        subject.predicate.should be_false
+        subject.predicate.should be_falsey
       end
 
     end

--- a/spec/unit/alf-compiler/default/test_project.rb
+++ b/spec/unit/alf-compiler/default/test_project.rb
@@ -63,7 +63,7 @@ module Alf
         it 'has a Clip cog' do
           subject.should be_a(Engine::Clip)
           subject.attributes.should eq(AttrList[:a])
-          subject.allbut.should be_false
+          subject.allbut.should be_falsey
         end
 
         it 'has the correct sub cog' do

--- a/spec/unit/alf-compiler/default/test_wrap.rb
+++ b/spec/unit/alf-compiler/default/test_wrap.rb
@@ -26,7 +26,7 @@ module Alf
       end
 
       it 'has the correct allbut' do
-        subject.allbut.should be_true
+        subject.allbut.should be_truthy
       end
 
       it 'has the correct sub-cog' do

--- a/spec/unit/alf-database/connection/test_assert.rb
+++ b/spec/unit/alf-database/connection/test_assert.rb
@@ -8,7 +8,7 @@ module Alf
       context 'with the result is not empty' do
         subject{ conn.assert!{ suppliers } }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context 'with the result is empty' do

--- a/spec/unit/alf-database/connection/test_close.rb
+++ b/spec/unit/alf-database/connection/test_close.rb
@@ -15,7 +15,7 @@ module Alf
 
       it 'should close the physical connection' do
         subject
-        @seen.should be_true
+        @seen.should be_truthy
       end
 
       it 'should close the connection itself' do

--- a/spec/unit/alf-database/connection/test_deny.rb
+++ b/spec/unit/alf-database/connection/test_deny.rb
@@ -18,7 +18,7 @@ module Alf
       context 'with the result is empty' do
         subject{ conn.deny!{ restrict(suppliers, ->{false}) } }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context 'with an error message' do

--- a/spec/unit/alf-database/connection/test_lock.rb
+++ b/spec/unit/alf-database/connection/test_lock.rb
@@ -10,7 +10,7 @@ module Alf
 
         it 'delegates to the underlying connection' do
           subject
-          @seen.should be_true
+          @seen.should be_truthy
         end
       end
 

--- a/spec/unit/alf-database/connection/test_reconnect.rb
+++ b/spec/unit/alf-database/connection/test_reconnect.rb
@@ -23,7 +23,7 @@ module Alf
 
         it 'should close the underlying connection' do
           subject
-          @closed.should be_true
+          @closed.should be_truthy
         end
       end
 
@@ -32,7 +32,7 @@ module Alf
 
         it 'should not close the underlying connection' do
           subject
-          @closed.should be_false
+          @closed.should be_falsey
         end
       end
 

--- a/spec/unit/alf-database/database/test_new.rb
+++ b/spec/unit/alf-database/database/test_new.rb
@@ -16,7 +16,7 @@ module Alf
       end
 
       it 'uses default options' do
-        subject.schema_cache?.should be_true
+        subject.schema_cache?.should be_truthy
       end
     end
 
@@ -28,7 +28,7 @@ module Alf
       end
 
       it 'uses default options' do
-        subject.schema_cache?.should be_true
+        subject.schema_cache?.should be_truthy
       end
     end
 
@@ -36,7 +36,7 @@ module Alf
       subject{ Database.new(adapter, schema_cache: false) }
 
       it 'set the options correctly' do
-        subject.schema_cache?.should be_false
+        subject.schema_cache?.should be_falsey
       end
     end
 

--- a/spec/unit/alf-engine/infer_heading/test_heading.rb
+++ b/spec/unit/alf-engine/infer_heading/test_heading.rb
@@ -10,19 +10,19 @@ module Alf
       context 'on a single tuple' do
         let(:tuple){ {id: 1, name: "Jones"} }
 
-        it{ should eq(Heading.new(id: Fixnum, name: String)) }
+        it{ should eq(Heading.new(id: Integer, name: String)) }
       end
 
       context 'on a tuple with tuple-valued attribute' do
         let(:tuple){ {id: 1, hobby: Tuple(name: "Programming")} }
 
-        it{ should eq(Heading.new(id: Fixnum, hobby: Tuple[name: String])) }
+        it{ should eq(Heading.new(id: Integer, hobby: Tuple[name: String])) }
       end
 
       context 'on a tuple with relation-valued attribute' do
         let(:tuple){ {id: 1, hobby: Relation(name: "Programming")} }
 
-        it{ should eq(Heading.new(id: Fixnum, hobby: Relation[name: String])) }
+        it{ should eq(Heading.new(id: Integer, hobby: Relation[name: String])) }
       end
 
     end

--- a/spec/unit/alf-engine/test_hierarchize.rb
+++ b/spec/unit/alf-engine/test_hierarchize.rb
@@ -4,7 +4,7 @@ module Alf
     describe Hierarchize do
 
       let(:type){
-        Relation.type(id: Fixnum, parent: Fixnum, name: String){|r| {subs: r} }
+        Relation.type(id: Integer, parent: Integer, name: String){|r| {subs: r} }
       }
 
       let(:operand){[
@@ -40,7 +40,7 @@ module Alf
         # take tuples
         got = x.to_a.sort{|t,u| t[:id] <=> u[:id] }
         exp = y.to_a.sort{|t,u| t[:id] <=> u[:id] }
-        
+
         # compare attributes
         got.zip(exp) do |e,f|
           [:id, :parent, :name].each do |a|
@@ -59,7 +59,7 @@ module Alf
       end
 
       it 'has pair-wise equal tuples' do
-        are_equal(resulting_relation, expected).should be_true
+        are_equal(resulting_relation, expected).should be_truthy
       end
 
       it 'computes expected relation' do

--- a/spec/unit/alf-engine/test_type_safe.rb
+++ b/spec/unit/alf-engine/test_type_safe.rb
@@ -3,7 +3,7 @@ module Alf
   module Engine
     describe TypeSafe do
 
-      let(:heading){ Heading.new(name: String, status: Fixnum) }
+      let(:heading){ Heading.new(name: String, status: Integer) }
       let(:cog){ TypeSafe.new(tuples, TypeCheck.new(heading, false)) }
 
       context 'when all valid tuples' do

--- a/spec/unit/alf-io/reader/test_initialize.rb
+++ b/spec/unit/alf-io/reader/test_initialize.rb
@@ -38,9 +38,9 @@ module Alf
       end
 
       context "with a File" do
-        let(:input){ Path.here.open('r') }
+        let(:input){ Path.file.open('r') }
         it 'should set the path correctly' do
-          subject.path.should eq(Path.here)
+          subject.path.should eq(Path.file)
         end
         after{ input.close rescue nil }
       end

--- a/spec/unit/alf-predicate/factory/shared/a_predicate_ast_node.rb
+++ b/spec/unit/alf-predicate/factory/shared/a_predicate_ast_node.rb
@@ -6,11 +6,11 @@ shared_examples_for "a predicate AST node" do
   it{ should be_a(Alf::Predicate::Expr) }
 
   specify{
-    (subject.tautology? == subject.is_a?(Alf::Predicate::Tautology)).should be_true
+    (subject.tautology? == subject.is_a?(Alf::Predicate::Tautology)).should be_truthy
   }
 
   specify{
-    (subject.contradiction? == subject.is_a?(Alf::Predicate::Contradiction)).should be_true
+    (subject.contradiction? == subject.is_a?(Alf::Predicate::Contradiction)).should be_truthy
   }
 
   specify{

--- a/spec/unit/alf-predicate/predicate/test_constant_variables.rb
+++ b/spec/unit/alf-predicate/predicate/test_constant_variables.rb
@@ -44,7 +44,7 @@ module Alf
       describe "on a negated OR" do
         let(:p){ !(Predicate.coerce(x: 2) | Predicate.coerce(y: 3)) }
 
-        pending("NNF would make constant_variables smarter"){
+        skip("NNF would make constant_variables smarter"){
           it{ should eq(AttrList[:x, :y]) }
         }
       end

--- a/spec/unit/alf-predicate/predicate/test_contradiction.rb
+++ b/spec/unit/alf-predicate/predicate/test_contradiction.rb
@@ -8,19 +8,19 @@ module Alf
       context "tautology" do
         subject{ Predicate.tautology }
 
-        it{ should be_false }
+        it{ should be_falsey }
       end
 
       context "contradiction" do
         subject{ Predicate.contradiction }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context "identifier" do
         subject{ Predicate.identifier(:x) }
 
-        it{ should be_false }
+        it{ should be_falsey }
       end
 
     end

--- a/spec/unit/alf-predicate/predicate/test_evaluate.rb
+++ b/spec/unit/alf-predicate/predicate/test_evaluate.rb
@@ -13,13 +13,13 @@ module Alf
         context 'on a matching tuple' do
           let(:scope){ Support::TupleScope.new(:name => "foo") }
 
-          it{ should be_true }
+          it{ should be_truthy }
         end
 
         context 'on a non-matching tuple' do
           let(:scope){ Support::TupleScope.new(:name => "bar") }
 
-          it{ should be_false }
+          it{ should be_falsey }
         end
       end
 
@@ -31,13 +31,13 @@ module Alf
         context 'on a matching tuple' do
           let(:scope){ Support::TupleScope.new(:name => "foo") }
 
-          it{ should be_true }
+          it{ should be_truthy }
         end
 
         context 'on a non-matching tuple' do
           let(:scope){ Support::TupleScope.new(:name => "bar") }
 
-          it{ should be_false }
+          it{ should be_falsey }
         end
       end
 
@@ -49,19 +49,19 @@ module Alf
         describe "on x == 2" do
           let(:scope){ Support::TupleScope.new(:x => 2) }
 
-          it{ should be_true }
+          it{ should be_truthy }
         end
 
         describe "on x == 1" do
           let(:scope){ Support::TupleScope.new(:x => 1) }
 
-          it{ should be_true }
+          it{ should be_truthy }
         end
 
         describe "on x == 3" do
           let(:scope){ Support::TupleScope.new(:x => 3) }
 
-          it{ should be_false }
+          it{ should be_falsey }
         end
       end
 

--- a/spec/unit/alf-predicate/predicate/test_hash_and_equal.rb
+++ b/spec/unit/alf-predicate/predicate/test_hash_and_equal.rb
@@ -13,14 +13,14 @@ module Alf
         let(:left) { Predicate.coerce(:x => 2) }
         let(:right){ Predicate.coerce(:x => 2) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       describe "on non equal predicates" do
         let(:left) { Predicate.coerce(:x => 2) }
         let(:right){ Predicate.coerce(:x => 3) }
 
-        it{ should be_false }
+        it{ should be_falsey }
       end
 
     end

--- a/spec/unit/alf-predicate/predicate/test_tautology.rb
+++ b/spec/unit/alf-predicate/predicate/test_tautology.rb
@@ -8,19 +8,19 @@ module Alf
       context "tautology" do
         subject{ Predicate.tautology }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context "contradiction" do
         subject{ Predicate.contradiction }
 
-        it{ should be_false }
+        it{ should be_falsey }
       end
 
       context "identifier" do
         subject{ Predicate.identifier(:x) }
 
-        it{ should be_false }
+        it{ should be_falsey }
       end
 
     end

--- a/spec/unit/alf-relation/relation/factored-types/test_coerce.rb
+++ b/spec/unit/alf-relation/relation/factored-types/test_coerce.rb
@@ -5,7 +5,7 @@ module Alf
     subject{ type.coerce(tuples) }
 
     context 'on single attributes' do
-      let(:type)    { Relation[name: String,  status: Fixnum]  }
+      let(:type)    { Relation[name: String,  status: Integer]  }
       let(:expected){ Relation(name: "Smith", status: 20)      }
       let(:tuples){
         [ {'name' => "Smith", 'status' => "20"} ]
@@ -39,9 +39,9 @@ module Alf
       it 'coerces the tuples as correct instances' do
         subject.all?{|t|
           puts t.class unless t.is_a?(tuple_type)
-          (tuple_type === t).should be_true
+          (tuple_type === t).should be_truthy
           t.should be_a(tuple_type)
-        }.should be_true
+        }.should be_truthy
       end
     end
 

--- a/spec/unit/alf-relation/relation/factored-types/test_comparisons.rb
+++ b/spec/unit/alf-relation/relation/factored-types/test_comparisons.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 module Alf
   describe Relation, '<=>' do
 
-    let(:type)     { Relation[name: String, status: Integer] }
-    let(:supertype){ Relation[name: String, status: Numeric] }
-    let(:subtype)  { Relation[name: String, status: Fixnum]  }
+    let(:type) { Relation[name: String, status: Integer] }
+    let(:supertype) { Relation[name: String, status: Numeric] }
 
     subject{ type <=> other }
 
@@ -26,12 +25,6 @@ module Alf
       it{ should eq(0) }
     end
 
-    context 'on a sub type' do
-      let(:other){ subtype }
-
-      it{ should eq(1) }
-    end
-
     context 'on a super type' do
       let(:other){ supertype }
 
@@ -41,27 +34,23 @@ module Alf
     context 'the shortcuts' do
 
       it 'the > shortcut classifies correctly' do
-        (supertype > supertype).should be_false
-        (supertype > type).should be_true
-        (supertype > subtype).should be_true
+        (supertype > supertype).should be_falsey
+        (supertype > type).should be_truthy
       end
 
       it 'the >= shortcut classifies correctly' do
-        (supertype >= supertype).should be_true
-        (supertype >= type).should be_true
-        (supertype >= subtype).should be_true
+        (supertype >= supertype).should be_truthy
+        (supertype >= type).should be_truthy
       end
 
       it 'the < shortcut classifies correctly' do
-        (supertype < supertype).should be_false
-        (supertype < type).should be_false
-        (supertype < subtype).should be_false
+        (supertype < supertype).should be_falsey
+        (supertype < type).should be_falsey
       end
 
       it 'the <= shortcut classifies correctly' do
-        (supertype <= supertype).should be_true
-        (supertype <= type).should be_false
-        (supertype <= subtype).should be_false
+        (supertype <= supertype).should be_truthy
+        (supertype <= type).should be_falsey
       end
     end
 

--- a/spec/unit/alf-relation/relation/factored-types/test_equality.rb
+++ b/spec/unit/alf-relation/relation/factored-types/test_equality.rb
@@ -9,19 +9,19 @@ module Alf
     context 'with itself' do
       let(:other){ type }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'with another equivalent' do
       let(:other){ Relation[name: String, status: Integer] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'with another, non equivalent' do
       let(:other){ Relation[name: String] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-relation/relation/factored-types/test_triple_equal.rb
+++ b/spec/unit/alf-relation/relation/factored-types/test_triple_equal.rb
@@ -7,18 +7,18 @@ module Alf
     subject{ type === value }
 
     context 'when the exact types' do
-      let(:heading){ Heading.new(name: String, status: Fixnum) }
+      let(:heading){ Heading.new(name: String, status: Integer) }
 
       context 'on a valid value built with itself' do
         let(:value){ type.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context 'on a valid value but built with Relation' do
         let(:value){ Relation.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
     end
 
@@ -28,13 +28,13 @@ module Alf
       context 'on a valid value built with itself' do
         let(:value){ type.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context 'on a valid value but built with Relation' do
         let(:value){ Relation.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
     end
 

--- a/spec/unit/alf-relation/relation/test_equality.rb
+++ b/spec/unit/alf-relation/relation/test_equality.rb
@@ -3,7 +3,7 @@ module Alf
   describe Relation, "equality" do
 
     let(:rel)   { Relation[id: Integer].coerce(id: 12) }
-    let(:subrel){ Relation[id:  Fixnum].coerce(id: 12) }
+    let(:subrel){ Relation[id:  Integer].coerce(id: 12) }
     let(:suprel){ Relation[id: Numeric].coerce(id: 12) }
 
     context '==' do

--- a/spec/unit/alf-relation/relation/test_hash.rb
+++ b/spec/unit/alf-relation/relation/test_hash.rb
@@ -9,19 +9,19 @@ module Alf
     context 'on purely equal relation' do
       let(:other){ Relation[id: Integer].coerce(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on equal relation but a subtype' do
-      let(:other){ Relation[id: Fixnum].coerce(id: 12) }
+      let(:other){ Relation[id: Integer].coerce(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on equal relation but a supertype' do
       let(:other){ Relation[id: Numeric].coerce(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-relation/tuple/factored-types/test_coerce.rb
+++ b/spec/unit/alf-relation/tuple/factored-types/test_coerce.rb
@@ -31,7 +31,7 @@ module Alf
     end
 
     context 'from a Tuple whose declared type hides the compatibility' do
-      let(:type) { Tuple[price: Fixnum] }
+      let(:type) { Tuple[price: Integer] }
       let(:tuple){ Tuple[price: Numeric].new(price: 12) }
 
       it{ should eq(type.new(price: 12))}

--- a/spec/unit/alf-relation/tuple/factored-types/test_comparisons.rb
+++ b/spec/unit/alf-relation/tuple/factored-types/test_comparisons.rb
@@ -4,7 +4,6 @@ module Alf
 
     let(:type)     { Tuple[name: String, status: Integer] }
     let(:supertype){ Tuple[name: String, status: Numeric] }
-    let(:subtype)  { Tuple[name: String, status: Fixnum]  }
 
     subject{ type <=> other }
 
@@ -26,12 +25,6 @@ module Alf
       it{ should eq(0) }
     end
 
-    context 'on a sub type' do
-      let(:other){ subtype }
-
-      it{ should eq(1) }
-    end
-
     context 'on a super type' do
       let(:other){ supertype }
 
@@ -41,27 +34,23 @@ module Alf
     context 'the shortcuts' do
 
       it 'the > shortcut classifies correctly' do
-        (supertype > supertype).should be_false
-        (supertype > type).should be_true
-        (supertype > subtype).should be_true
+        (supertype > supertype).should be_falsey
+        (supertype > type).should be_truthy
       end
 
       it 'the >= shortcut classifies correctly' do
-        (supertype >= supertype).should be_true
-        (supertype >= type).should be_true
-        (supertype >= subtype).should be_true
+        (supertype >= supertype).should be_truthy
+        (supertype >= type).should be_truthy
       end
 
       it 'the < shortcut classifies correctly' do
-        (supertype < supertype).should be_false
-        (supertype < type).should be_false
-        (supertype < subtype).should be_false
+        (supertype < supertype).should be_falsey
+        (supertype < type).should be_falsey
       end
 
       it 'the <= shortcut classifies correctly' do
-        (supertype <= supertype).should be_true
-        (supertype <= type).should be_false
-        (supertype <= subtype).should be_false
+        (supertype <= supertype).should be_truthy
+        (supertype <= type).should be_falsey
       end
     end
 

--- a/spec/unit/alf-relation/tuple/factored-types/test_equality.rb
+++ b/spec/unit/alf-relation/tuple/factored-types/test_equality.rb
@@ -9,19 +9,19 @@ module Alf
     context 'with itself' do
       let(:other){ type }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'with another equivalent' do
       let(:other){ Tuple[name: String, status: Integer] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'with another, non equivalent' do
       let(:other){ Tuple[name: String] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-relation/tuple/factored-types/test_triple_equal.rb
+++ b/spec/unit/alf-relation/tuple/factored-types/test_triple_equal.rb
@@ -7,18 +7,18 @@ module Alf
     subject{ type === value }
 
     context 'when the exact types' do
-      let(:heading){ Heading.new(name: String, status: Fixnum) }
+      let(:heading){ Heading.new(name: String, status: Integer) }
 
       context 'on a valid value built with itself' do
         let(:value){ type.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context 'on a valid value but built with Tuple' do
         let(:value){ Tuple.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
     end
 
@@ -28,13 +28,13 @@ module Alf
       context 'on a valid value built with itself' do
         let(:value){ type.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
 
       context 'on a valid value but built with Tuple' do
         let(:value){ Tuple.coerce(name: "Smith", status: 20) }
 
-        it{ should be_true }
+        it{ should be_truthy }
       end
     end
 
@@ -42,14 +42,14 @@ module Alf
       let(:heading){ {sid: String, supplies: Relation[{}]} }
       let(:value){ Tuple.coerce(sid: "S5", supplies: Alf::Relation([])) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'with a DUM RVA and a master Relation type' do
       let(:heading){ {sid: String, supplies: Relation} }
       let(:value){ Tuple.coerce(sid: "S5", supplies: Alf::Relation([])) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-relation/tuple/test_equality.rb
+++ b/spec/unit/alf-relation/tuple/test_equality.rb
@@ -9,19 +9,19 @@ module Alf
     context 'on purely equal tuple' do
       let(:other){ Tuple[id: Integer].new(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on equal tuple but a subtype' do
-      let(:other){ Tuple[id: Fixnum].new(id: 12) }
+      let(:other){ Tuple[id: Integer].new(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on equal tuple but a supertype' do
       let(:other){ Tuple[id: Numeric].new(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-relation/tuple/test_hash.rb
+++ b/spec/unit/alf-relation/tuple/test_hash.rb
@@ -9,19 +9,19 @@ module Alf
     context 'on purely equal tuple' do
       let(:other){ Tuple[id: Integer].new(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on equal tuple but a subtype' do
-      let(:other){ Tuple[id: Fixnum].new(id: 12) }
+      let(:other){ Tuple[id: Integer].new(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on equal tuple but a supertype' do
       let(:other){ Tuple[id: Numeric].new(id: 12) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-relation/tuple/test_heading.rb
+++ b/spec/unit/alf-relation/tuple/test_heading.rb
@@ -13,7 +13,7 @@ module Alf
     describe 'on a tuple factored through coercion' do
       let(:tuple){ Tuple.coerce(status: 12) }
 
-      it{ should eq(Heading.new(status: Fixnum)) }
+      it{ should eq(Heading.new(status: Integer)) }
     end
 
   end

--- a/spec/unit/alf-relation/tuple/test_triple_equal.rb
+++ b/spec/unit/alf-relation/tuple/test_triple_equal.rb
@@ -13,7 +13,7 @@ module Alf
         type.new(price: 12.0)
       }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when applied to a most specific tuple than declared' do
@@ -26,7 +26,7 @@ module Alf
       }
 
       it{
-        pending("most-specific types not implemented"){ should be_true }
+        skip("most-specific types not implemented"){ should be_truthy }
       }
     end
 
@@ -38,7 +38,7 @@ module Alf
         type.new(:default => nil)
       }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-relvar/read_only/test_type.rb
+++ b/spec/unit/alf-relvar/read_only/test_type.rb
@@ -9,7 +9,7 @@ module Alf
       subject{ rv.type }
 
       it 'is as expected' do
-        subject.should eq(Relation[id: Fixnum])
+        subject.should eq(Relation[id: Integer])
       end
 
     end

--- a/spec/unit/alf-relvar/shared/test_empty.rb
+++ b/spec/unit/alf-relvar/shared/test_empty.rb
@@ -8,13 +8,13 @@ module Alf
     context 'on an empty relvar' do
       let(:to_cog){ [] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on an non empty relvar' do
       let(:to_cog){ [ 1 ] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-support/config/test_dup.rb
+++ b/spec/unit/alf-support/config/test_dup.rb
@@ -30,9 +30,9 @@ module Alf
         end
 
         it 'should keep the semantics of Proc options' do
-          subject.aproc?.should be_true
+          subject.aproc?.should be_truthy
           subject.ready = true
-          subject.aproc?.should be_false
+          subject.aproc?.should be_falsey
         end
       end
 
@@ -48,8 +48,8 @@ module Alf
           lambda{
             subject.ready = true
           }.should_not raise_error
-          subject.ready?.should be_true
-          config.ready?.should be_false
+          subject.ready?.should be_truthy
+          config.ready?.should be_falsey
         end
       end
 

--- a/spec/unit/alf-support/config/test_new.rb
+++ b/spec/unit/alf-support/config/test_new.rb
@@ -45,7 +45,7 @@ module Alf
         }
 
         it 'yields the block' do
-          subject.ready?.should be_true
+          subject.ready?.should be_truthy
         end
       end
 
@@ -53,7 +53,7 @@ module Alf
         subject{ conf_subclass.new }
 
         it 'uses default values' do
-          subject.ready?.should be_false
+          subject.ready?.should be_falsey
         end
       end
 

--- a/spec/unit/alf-support/scope/test_branch.rb
+++ b/spec/unit/alf-support/scope/test_branch.rb
@@ -13,12 +13,12 @@ module Alf
         it_behaves_like 'A scope'
 
         it 'responds to the tuple keys' do
-          subject.respond_to?(:here).should be_true
+          subject.respond_to?(:here).should be_truthy
           subject.here.should eq("here")
         end
 
         it "responds to helper's methods" do
-          subject.respond_to?(:world).should be_true
+          subject.respond_to?(:world).should be_truthy
           subject.world.should eq('world')
         end
       end

--- a/spec/unit/alf-support/scope/test_evaluate.rb
+++ b/spec/unit/alf-support/scope/test_evaluate.rb
@@ -19,7 +19,7 @@ module Alf
             scope.evaluate("no_such_one", "a file", 65)
             raise "Should not pass here"
           rescue NameError => ex
-            ex.backtrace.any?{|l| l =~ /a file:65/}.should be_true
+            ex.backtrace.any?{|l| l =~ /a file:65/}.should be_truthy
           end
         end
       end

--- a/spec/unit/alf-support/scope/test_respond_to.rb
+++ b/spec/unit/alf-support/scope/test_respond_to.rb
@@ -14,7 +14,7 @@ module Alf
         it_behaves_like "A scope"
 
         it "responds to helpers' methods" do
-          subject.respond_to?(:world).should be_true
+          subject.respond_to?(:world).should be_truthy
         end
       end
 
@@ -24,7 +24,7 @@ module Alf
         it_behaves_like "A scope"
 
         it "responds to parent scope methods" do
-          subject.respond_to?(:world).should be_true
+          subject.respond_to?(:world).should be_truthy
         end
       end
 

--- a/spec/unit/alf-support/test_tuple_scope.rb
+++ b/spec/unit/alf-support/test_tuple_scope.rb
@@ -7,8 +7,8 @@ module Alf
 
       it "should install methods properly" do
         scope.__set_tuple(:hello => "a", :world => "b")
-        scope.respond_to?(:hello).should be_true
-        scope.respond_to?(:world).should be_true
+        scope.respond_to?(:hello).should be_truthy
+        scope.respond_to?(:world).should be_truthy
       end
 
       it "should behave correctly" do
@@ -22,12 +22,12 @@ module Alf
 
       it "should allow instance evaluating on exprs" do
         scope.__set_tuple(:tested => 1)
-        scope.evaluate{ tested < 1 }.should be_false
+        scope.evaluate{ tested < 1 }.should be_falsey
       end
 
       it "should support an attribute called :path" do
         scope.__set_tuple(:path => 1)
-        scope.evaluate{ path < 1 }.should be_false
+        scope.evaluate{ path < 1 }.should be_falsey
       end
 
       it "should support calling Tuple and Relation" do

--- a/spec/unit/alf-support/tuple_scope/test_respond_to.rb
+++ b/spec/unit/alf-support/tuple_scope/test_respond_to.rb
@@ -9,9 +9,9 @@ module Alf
         it_behaves_like "A scope"
 
         it 'responds to [], to_s and inspect' do
-          scope.respond_to?(:[]).should be_true
-          scope.respond_to?(:to_s).should be_true
-          scope.respond_to?(:inspect).should be_true
+          scope.respond_to?(:[]).should be_truthy
+          scope.respond_to?(:to_s).should be_truthy
+          scope.respond_to?(:inspect).should be_truthy
         end
       end
 
@@ -21,7 +21,7 @@ module Alf
         it_behaves_like "A scope"
 
         it 'responds to tuple keys' do
-          scope.respond_to?(:hello).should be_true
+          scope.respond_to?(:hello).should be_truthy
         end
       end
 
@@ -31,7 +31,7 @@ module Alf
         it_behaves_like "A scope"
 
         it "responds to helpers' methods" do
-          scope.respond_to?(:hello).should be_true
+          scope.respond_to?(:hello).should be_truthy
         end
       end
 

--- a/spec/unit/alf-types/attr_list/test_hash_and_eql.rb
+++ b/spec/unit/alf-types/attr_list/test_hash_and_eql.rb
@@ -12,35 +12,35 @@ module Alf
       let(:left){ AttrList[] }
       let(:right){ AttrList[] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context "when the same lists in same order" do
       let(:left){ AttrList[:a, :b] }
       let(:right){ AttrList[:a, :b] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context "when the same lists in different order" do
       let(:left){ AttrList[:a, :b] }
       let(:right){ AttrList[:b, :a] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context "when not the same lists" do
       let(:left){ AttrList[:a, :b] }
       let(:right){ AttrList[:b, :c] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context "when disjoint" do
       let(:left){ AttrList[:a, :b] }
       let(:right){ AttrList[:c, :d] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-types/attr_list/test_include.rb
+++ b/spec/unit/alf-types/attr_list/test_include.rb
@@ -9,13 +9,13 @@ module Alf
     context 'when included' do
       let(:attribute){ :id }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when not included' do
       let(:attribute){ :notthatone }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-types/attr_list/test_intersect.rb
+++ b/spec/unit/alf-types/attr_list/test_intersect.rb
@@ -8,28 +8,28 @@ module Alf
       let(:left){ AttrList[:id, :name] }
       let(:right){ AttrList[:name, :id] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when not equal but intersect' do
       let(:left){ AttrList[:id] }
       let(:right){ AttrList[:name, :id] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when disjoint' do
       let(:left){ AttrList[:status] }
       let(:right){ AttrList[:name, :id] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context 'when both empty' do
       let(:left){ AttrList[] }
       let(:right){ AttrList[] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-types/attr_list/test_sameset.rb
+++ b/spec/unit/alf-types/attr_list/test_sameset.rb
@@ -8,28 +8,28 @@ module Alf
       let(:left){ AttrList[:id, :name] }
       let(:right){ AttrList[:name, :id] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when not equal' do
       let(:left){ AttrList[:id] }
       let(:right){ AttrList[:name, :id] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context 'when disjoint' do
       let(:left){ AttrList[:status] }
       let(:right){ AttrList[:name, :id] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context 'when both empty' do
       let(:left){ AttrList[] }
       let(:right){ AttrList[] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-types/attr_list/test_subset.rb
+++ b/spec/unit/alf-types/attr_list/test_subset.rb
@@ -7,10 +7,10 @@ module Alf
       let(:right){ AttrList[:name, :id] }
 
       it 'returns true if non proper' do
-        left.subset?(right).should be_true
+        left.subset?(right).should be_truthy
       end
       it 'returns false if proper' do
-        left.subset?(right, true).should be_false
+        left.subset?(right, true).should be_falsey
       end
     end
 
@@ -19,10 +19,10 @@ module Alf
       let(:right){ AttrList[] }
 
       it 'returns true if non proper' do
-        left.subset?(right).should be_true
+        left.subset?(right).should be_truthy
       end
       it 'returns false if proper' do
-        left.subset?(right, true).should be_false
+        left.subset?(right, true).should be_falsey
       end
     end
 
@@ -31,8 +31,8 @@ module Alf
       let(:right){ AttrList[:name, :id] }
 
       it 'returns false' do
-        left.subset?(right).should be_false
-        left.subset?(right, true).should be_false
+        left.subset?(right).should be_falsey
+        left.subset?(right, true).should be_falsey
       end
     end
 
@@ -41,8 +41,8 @@ module Alf
       let(:right){ AttrList[:id, :name] }
 
       it 'returns true' do
-        left.subset?(right).should be_true
-        left.subset?(right, true).should be_true
+        left.subset?(right).should be_truthy
+        left.subset?(right, true).should be_truthy
       end
     end
 

--- a/spec/unit/alf-types/attr_list/test_superset.rb
+++ b/spec/unit/alf-types/attr_list/test_superset.rb
@@ -7,10 +7,10 @@ module Alf
       let(:right){ AttrList[:name, :id] }
 
       it 'returns true if non proper' do
-        left.superset?(right).should be_true
+        left.superset?(right).should be_truthy
       end
       it 'returns false if proper' do
-        left.superset?(right, true).should be_false
+        left.superset?(right, true).should be_falsey
       end
     end
 
@@ -19,10 +19,10 @@ module Alf
       let(:right){ AttrList[] }
 
       it 'returns true if non proper' do
-        left.superset?(right).should be_true
+        left.superset?(right).should be_truthy
       end
       it 'returns false if proper' do
-        left.superset?(right, true).should be_false
+        left.superset?(right, true).should be_falsey
       end
     end
 
@@ -31,8 +31,8 @@ module Alf
       let(:right){ AttrList[:name, :id] }
 
       it 'returns false' do
-        left.superset?(right).should be_false
-        left.superset?(right, true).should be_false
+        left.superset?(right).should be_falsey
+        left.superset?(right, true).should be_falsey
       end
     end
 
@@ -41,8 +41,8 @@ module Alf
       let(:right){ AttrList[:name] }
 
       it 'returns true' do
-        left.superset?(right).should be_true
-        left.superset?(right, true).should be_true
+        left.superset?(right).should be_truthy
+        left.superset?(right, true).should be_truthy
       end
     end
 

--- a/spec/unit/alf-types/attr_name/test_triple_equal.rb
+++ b/spec/unit/alf-types/attr_name/test_triple_equal.rb
@@ -3,24 +3,24 @@ module Alf
   describe AttrName, "===" do
 
     it "should allow normal names" do
-      (AttrName === :city).should be_true
+      (AttrName === :city).should be_truthy
     end
 
     it "should allow underscores" do
-      (AttrName === :my_city).should be_true
+      (AttrName === :my_city).should be_truthy
     end
 
     it "should allow numbers" do
-      (AttrName === :city2).should be_true
+      (AttrName === :city2).should be_truthy
     end
 
     it "should allow question marks and bang" do
-      (AttrName === :big?).should be_true
-      (AttrName === :big!).should be_true
+      (AttrName === :big?).should be_truthy
+      (AttrName === :big!).should be_truthy
     end
 
     it "should not allow strange attribute names" do
-      (AttrName === "$$$".to_sym).should be_false
+      (AttrName === "$$$".to_sym).should be_falsey
     end
 
   end

--- a/spec/unit/alf-types/heading/class/test_infer.rb
+++ b/spec/unit/alf-types/heading/class/test_infer.rb
@@ -13,7 +13,7 @@ module Alf
     context 'with a Hash' do
       let(:arg){ {:foo => 20} }
 
-      it{ should eq(Heading.new foo: Fixnum) }
+      it{ should eq(Heading.new foo: Integer) }
     end
 
     context 'with an array of hashes' do
@@ -22,5 +22,5 @@ module Alf
       it{ should eq(Heading.new foo: Numeric) }
     end
 
-  end 
+  end
 end

--- a/spec/unit/alf-types/heading/test_comparison.rb
+++ b/spec/unit/alf-types/heading/test_comparison.rb
@@ -40,14 +40,8 @@ module Alf
       it{ should eq(0) }
     end
 
-    context 'with a partial sub heading' do
-      let(:other){ Heading.new(name: String, status: Fixnum, active: Boolean) }
-
-      it{ should eq(1) }
-    end
-
     context 'with a full sub heading' do
-      let(:other){ Heading.new(name: String, status: Fixnum, active: TrueClass) }
+      let(:other){ Heading.new(name: String, status: Integer, active: TrueClass) }
 
       it{ should eq(1) }
     end
@@ -65,19 +59,13 @@ module Alf
     end
 
     context 'with a mixed heading' do
-      let(:other){ Heading.new(name: Object, status: Fixnum, active: Boolean) }
+      let(:other){ Heading.new(name: Object, status: Integer, active: Boolean) }
 
-      it{ should be_nil }
+      it{ should eq(-1) }
     end
 
     context 'when RVAs are present' do
       let(:heading){ Heading.new(prices: Relation[price: Numeric]) }
-
-      context 'with a sub-heading' do
-        let(:other){ Heading.new(prices: Relation[price: Float]) }
-
-        it{ should eq(1) }
-      end
 
       context 'with a super-heading' do
         let(:other){ Heading.new(prices: Relation[price: Object]) }

--- a/spec/unit/alf-types/heading/test_intersection.rb
+++ b/spec/unit/alf-types/heading/test_intersection.rb
@@ -19,7 +19,7 @@ module Alf
     end
 
     context 'with non disjoint headings and sub types' do
-      let(:left) { Heading[:id => Fixnum,  :name => String] }
+      let(:left) { Heading[:id => Integer,  :name => String] }
       let(:right){ Heading[:id => Integer, :status => Integer] }
 
       it { should eq(Heading[:id => Integer]) }

--- a/spec/unit/alf-types/heading/test_triple_equal.rb
+++ b/spec/unit/alf-types/heading/test_triple_equal.rb
@@ -9,32 +9,32 @@ module Alf
     context 'on a conforming Hash' do
       let(:tuple){ {name: "Smith", status: 20} }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on a conforming Tuple' do
       let(:tuple){ Tuple(name: "Smith", status: 20) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on a non conforming Hash (missing attributes)' do
       let(:tuple){ {name: "Smith"} }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context 'on a non conforming Hash (too many attributes)' do
       let(:tuple){ {name: "Smith", status: 20, city: "London"} }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context 'on a non conforming Hash (type mismatch)' do
       let(:tuple){ {name: "Smith", status: "20"} }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
-  end 
+  end
 end

--- a/spec/unit/alf-types/heading/test_union.rb
+++ b/spec/unit/alf-types/heading/test_union.rb
@@ -18,16 +18,16 @@ module Alf
     end
 
     it "should work compute supertype on non-disjoint headings" do
-      h1 = Heading[:age => Fixnum, :name => String]
+      h1 = Heading[:age => Integer, :name => String]
       h2 = Heading[:age => Integer]
       (h1 + h2).should eq(Heading[:age => Integer, :name => String])
     end
 
     it "should be aliased as join" do
-      h1 = Heading[:age => Fixnum, :name => String]
+      h1 = Heading[:age => Integer, :name => String]
       h2 = Heading[:age => Integer]
       h1.join(h2).should eq(Heading[:age => Integer, :name => String])
     end
 
-  end 
+  end
 end

--- a/spec/unit/alf-types/keys/test_all.rb
+++ b/spec/unit/alf-types/keys/test_all.rb
@@ -4,14 +4,14 @@ module Alf
 
     subject{ keys.all?{|k| (k & [:name]).empty? } }
 
-    let(:keys) { 
+    let(:keys) {
       Keys[ [:a], [:name], [:last, :name] ]
     }
-    let(:expected) { 
+    let(:expected) {
       Keys[ [:a] ]
     }
 
-    it{ should be_false }
+    it{ should be_falsey }
 
   end
 end

--- a/spec/unit/alf-types/keys/test_any.rb
+++ b/spec/unit/alf-types/keys/test_any.rb
@@ -4,14 +4,14 @@ module Alf
 
     subject{ keys.any?{|k| (k & [:name]).empty? } }
 
-    let(:keys) { 
+    let(:keys) {
       Keys[ [:a], [:name], [:last, :name] ]
     }
-    let(:expected) { 
+    let(:expected) {
       Keys[ [:a] ]
     }
 
-    it{ should be_true }
+    it{ should be_truthy }
 
   end
 end

--- a/spec/unit/alf-types/keys/test_empty.rb
+++ b/spec/unit/alf-types/keys/test_empty.rb
@@ -7,13 +7,13 @@ module Alf
     context 'on empty Keys' do
       let(:keys){ Keys.new [] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on non empty Keys' do
       let(:keys){ Keys.new [ AttrList[:a] ] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-types/keys/test_hash_and_equal.rb
+++ b/spec/unit/alf-types/keys/test_hash_and_equal.rb
@@ -5,28 +5,28 @@ module Alf
     subject{ left == right }
 
     after do
-      (left.hash == right.hash).should be_true if subject
+      (left.hash == right.hash).should be_truthy if subject
     end
 
     context 'on empty Keys' do
       let(:left) { Keys.new [] }
       let(:right){ Keys.new [] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on non-empty equal Keys' do
       let(:left) { Keys.new [ AttrList[], AttrList[:b, :a] ] }
       let(:right){ Keys.new [ AttrList[:a, :b], AttrList[] ] }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'on non equal Keys' do
       let(:left) { Keys.new [ AttrList[:b, :a] ] }
       let(:right){ Keys.new [ AttrList[:a, :c] ] }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-types/ordering/test_lte.rb
+++ b/spec/unit/alf-types/ordering/test_lte.rb
@@ -8,35 +8,35 @@ module Alf
       let(:o1){ Ordering::EMPTY  }
       let(:o2){ Ordering.new([]) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when equal' do
       let(:o1){ Ordering.new([[:a, :asc], [:b, :desc]]) }
       let(:o2){ Ordering.new([[:a, :asc], [:b, :desc]]) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when subsumed' do
       let(:o1){ Ordering.new([[:a, :asc]]) }
       let(:o2){ Ordering.new([[:a, :asc], [:b, :desc]]) }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
     context 'when larger' do
       let(:o1){ Ordering.new([[:a, :asc], [:b, :desc]]) }
       let(:o2){ Ordering.new([[:a, :asc]]) }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context 'when different' do
       let(:o1){ Ordering.new([[:a, :asc]]) }
       let(:o2){ Ordering.new([[:a, :desc]]) }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
   end

--- a/spec/unit/alf-types/ordering/test_sorter.rb
+++ b/spec/unit/alf-types/ordering/test_sorter.rb
@@ -60,7 +60,7 @@ module Alf
       }
 
       it 'should sort correctly' do
-        pending{
+        skip{
           tuples.sort(&subject).should eq(expected)
         }
       end

--- a/spec/unit/alf-types/selector/test_composite_q.rb
+++ b/spec/unit/alf-types/selector/test_composite_q.rb
@@ -7,13 +7,13 @@ module Alf
     context 'on a single' do
       let(:selector){ Selector.coerce(:name) }
 
-      it { should be_false }
+      it { should be_falsey }
     end
 
     context 'on a composite' do
       let(:selector){ Selector.coerce([:a, :name]) }
 
-      it { should be_true }
+      it { should be_truthy }
     end
 
   end

--- a/spec/unit/alf-types/selector/test_simple_q.rb
+++ b/spec/unit/alf-types/selector/test_simple_q.rb
@@ -7,13 +7,13 @@ module Alf
     context 'on a single' do
       let(:selector){ Selector.coerce(:name) }
 
-      it { should be_true }
+      it { should be_truthy }
     end
 
     context 'on a composite' do
       let(:selector){ Selector.coerce([:a, :name]) }
 
-      it { should be_false }
+      it { should be_falsey }
     end
 
   end

--- a/spec/unit/alf-types/size/test_triple_equal.rb
+++ b/spec/unit/alf-types/size/test_triple_equal.rb
@@ -4,20 +4,20 @@ module Alf
     describe Size, "===" do
 
       it 'should recognize 0' do
-        (Size === 0).should be_true
+        (Size === 0).should be_truthy
       end
 
       it 'should recognize any positive integer' do
-        (Size === 10).should be_true
+        (Size === 10).should be_truthy
       end
 
       it 'should not recognize negative integers' do
-        (Size === -1).should be_false
+        (Size === -1).should be_falsey
       end
 
       it 'should not recognize non integers' do
-        (Size === 10.0).should be_false
-        (Size === "12").should be_false
+        (Size === 10.0).should be_falsey
+        (Size === "12").should be_falsey
       end
 
     end

--- a/spec/unit/alf-types/test_class_methods.rb
+++ b/spec/unit/alf-types/test_class_methods.rb
@@ -10,8 +10,8 @@ module Alf
       end
 
       it 'works with related types' do
-        common_super_type(Fixnum, Integer).should eq(Integer)
-        common_super_type(Fixnum, Float).should eq(Numeric)
+        common_super_type(Integer, Integer).should eq(Integer)
+        common_super_type(Integer, Float).should eq(Numeric)
       end
 
       it 'works with true/false/boolean classes' do
@@ -22,7 +22,7 @@ module Alf
       end
 
       it 'fallbacks to Object' do
-        common_super_type(Fixnum, String).should eq(Object)
+        common_super_type(Integer, String).should eq(Object)
       end
 
       it 'works nicely on same relation types' do
@@ -32,7 +32,7 @@ module Alf
       end
 
       it 'works nicely on compatible relation types' do
-        left  = Relation[pid: Fixnum]
+        left  = Relation[pid: Integer]
         right = Relation[pid: Integer]
         common_super_type(left, right).should eq(right)
       end
@@ -44,7 +44,7 @@ module Alf
       end
 
       it 'works nicely on compatible relation types' do
-        left  = Tuple[pid: Fixnum]
+        left  = Tuple[pid: Integer]
         right = Tuple[pid: Integer]
         common_super_type(left, right).should eq(right)
       end

--- a/spec/unit/alf-types/tuple_computation/test_empty.rb
+++ b/spec/unit/alf-types/tuple_computation/test_empty.rb
@@ -9,7 +9,7 @@ module Alf
         TupleComputation[big?: ->{}, who: ->{}]
       }
 
-      it{ should be_false }
+      it{ should be_falsey }
     end
 
     context 'when empty' do
@@ -17,7 +17,7 @@ module Alf
         TupleComputation[{}]
       }
 
-      it{ should be_true }
+      it{ should be_truthy }
     end
 
   end

--- a/spec/unit/alf-types/tuple_computation/test_to_heading.rb
+++ b/spec/unit/alf-types/tuple_computation/test_to_heading.rb
@@ -14,7 +14,7 @@ module Alf
 
     context 'with proper type inference' do
       it{
-        pending "type inference on expressions not implemented" do
+        skip "type inference on expressions not implemented" do
           should eq(Heading[:big? => Boolean, :who => String])
         end
       }

--- a/spec/unit/alf-types/type_check/test_triple_equal.rb
+++ b/spec/unit/alf-types/type_check/test_triple_equal.rb
@@ -13,44 +13,44 @@ module Alf
 
       context 'when strict' do
         let(:type_check){ TypeCheck.new(heading) }
-        
+
         it 'accepts the valid tuple only' do
-          (type_check === tuple).should be_true
-          (type_check === missing).should be_false
-          (type_check === extra).should be_false
-          (type_check === mix).should be_false
-          (type_check === invalid).should be_false
+          (type_check === tuple).should be_truthy
+          (type_check === missing).should be_falsey
+          (type_check === extra).should be_falsey
+          (type_check === mix).should be_falsey
+          (type_check === invalid).should be_falsey
         end
       end
-      
+
       context 'when not strict' do
         let(:type_check){ TypeCheck.new(heading, false) }
-      
+
         it 'accepts the valid tuple and its projections' do
-          (type_check === tuple).should be_true
-          (type_check === missing).should be_true
-          (type_check === extra).should be_false
-          (type_check === mix).should be_false
-          (type_check === invalid).should be_false
+          (type_check === tuple).should be_truthy
+          (type_check === missing).should be_truthy
+          (type_check === extra).should be_falsey
+          (type_check === mix).should be_falsey
+          (type_check === invalid).should be_falsey
         end
       end
 
       context 'when passed invalid tuples' do
         let(:type_check){ TypeCheck.new(heading) }
-      
+
         it 'rejects them simply' do
-          (type_check === 12).should be_false
-          (type_check === nil).should be_false
-          (type_check === self).should be_false
-          (type_check === {'name' => 'Smith', 'status' => 20}).should be_false
+          (type_check === 12).should be_falsey
+          (type_check === nil).should be_falsey
+          (type_check === self).should be_falsey
+          (type_check === {'name' => 'Smith', 'status' => 20}).should be_falsey
         end
       end
 
       context 'when passed a real Tuple' do
         let(:type_check){ TypeCheck.new(heading) }
-      
+
         it 'accepts it if valid' do
-          (type_check === Tuple(tuple)).should be_true
+          (type_check === Tuple(tuple)).should be_truthy
         end
       end
     end

--- a/spec/unit/alf-update/deleter/test_autonum.rb
+++ b/spec/unit/alf-update/deleter/test_autonum.rb
@@ -20,7 +20,7 @@ module Alf
         let(:predicate){ Predicate.eq(:auto => 1) }
 
         it 'requests the deletion on :suppliers' do
-          pending "need for Predicate.in" do
+          skip "need for Predicate.in" do
             subject
           end
         end

--- a/spec/unit/alf-update/deleter/test_defaults.rb
+++ b/spec/unit/alf-update/deleter/test_defaults.rb
@@ -20,7 +20,7 @@ module Alf
         let(:predicate){ Predicate.eq(:foo => 1) }
 
         it 'requests the deletion on :suppliers' do
-          pending "need for Predicate.in" do
+          skip "need for Predicate.in" do
             subject
           end
         end

--- a/spec/unit/alf-update/deleter/test_extend.rb
+++ b/spec/unit/alf-update/deleter/test_extend.rb
@@ -20,7 +20,7 @@ module Alf
         let(:predicate){ Predicate.eq(:foo => 1) }
 
         it 'requests the deletion on :suppliers' do
-          pending "need for Predicate.in" do
+          skip "need for Predicate.in" do
             subject
           end
         end

--- a/spec/unit/alf-update/deleter/test_group.rb
+++ b/spec/unit/alf-update/deleter/test_group.rb
@@ -20,7 +20,7 @@ module Alf
         let(:predicate){ Predicate.eq(:foo => 1) }
 
         it 'requests the deletion on :suppliers' do
-          pending "need for Predicate.in" do
+          skip "need for Predicate.in" do
             subject
           end
         end

--- a/spec/unit/alf-update/deleter/test_rank.rb
+++ b/spec/unit/alf-update/deleter/test_rank.rb
@@ -20,7 +20,7 @@ module Alf
         let(:predicate){ Predicate.eq(:rank => 1) }
 
         it 'requests the deletion on :suppliers' do
-          pending "need for Predicate.in" do
+          skip "need for Predicate.in" do
             subject
           end
         end

--- a/spec/unit/alf-update/deleter/test_rename.rb
+++ b/spec/unit/alf-update/deleter/test_rename.rb
@@ -20,7 +20,7 @@ module Alf
         let(:predicate){ Predicate.eq(:location => "London") }
 
         it 'requests the deletion on :suppliers' do
-          pending "need for Predicate#rename" do
+          skip "need for Predicate#rename" do
             subject
           end
         end

--- a/spec/unit/alf-update/deleter/test_wrap.rb
+++ b/spec/unit/alf-update/deleter/test_wrap.rb
@@ -20,7 +20,7 @@ module Alf
         let(:predicate){ Predicate.eq(:foo => 1) }
 
         it 'requests the deletion on :suppliers' do
-          pending "need for Predicate.in" do
+          skip "need for Predicate.in" do
             subject
           end
         end

--- a/spec/unit/alf-update/inserter/test_clip.rb
+++ b/spec/unit/alf-update/inserter/test_clip.rb
@@ -10,7 +10,7 @@ module Alf
       subject{ insert(expr, inserted) }
 
       it 'requests the insertion of the tuples on :suppliers' do
-        pending "defaults" do
+        skip "defaults" do
           subject
           db_context.requests.should eq([ [:insert, :suppliers, expected] ])
         end

--- a/spec/unit/alf-update/inserter/test_project.rb
+++ b/spec/unit/alf-update/inserter/test_project.rb
@@ -10,7 +10,7 @@ module Alf
       subject{ insert(expr, inserted) }
 
       it 'requests the insertion of the tuples on :suppliers' do
-        pending "defaults" do
+        skip "defaults" do
           subject
           db_context.requests.should eq([ [:insert, :suppliers, expected] ])
         end


### PR DESCRIPTION
When moving to ruby 2.6 and updating dependencies :
`be_true/be_false` => `be_truthy/be_falsey`
`Fixnum/Bignum` => `Integer` so all tests related to subtypes are not relevant anymore